### PR TITLE
Run custom portal teardown before base block removal

### DIFF
--- a/src/main/java/net/createteleporters/block/CustomPortalBaseBlock.java
+++ b/src/main/java/net/createteleporters/block/CustomPortalBaseBlock.java
@@ -118,9 +118,8 @@ public class CustomPortalBaseBlock extends Block implements EntityBlock {
 
 	@Override
 	public boolean onDestroyedByPlayer(BlockState blockstate, Level world, BlockPos pos, Player entity, boolean willHarvest, FluidState fluid) {
-		boolean retval = super.onDestroyedByPlayer(blockstate, world, pos, entity, willHarvest, fluid);
 		CustomPortalBaseBlockDestroyedByPlayerProcedure.execute(world, pos.getX(), pos.getY(), pos.getZ(), blockstate);
-		return retval;
+		return super.onDestroyedByPlayer(blockstate, world, pos, entity, willHarvest, fluid);
 	}
 
 	@Override


### PR DESCRIPTION
### Motivation
- The custom portal base's `onDestroyedByPlayer` previously called `super` first which can remove the block entity and its NBT, causing the teardown procedure to lack stored portal dimensions and fail to clear all interior portal blocks.
- Breaking the outer `quantum_casing` removed the full portal interior, so controller-break behavior should match frame-break behavior.
- Preserve block entity data during teardown so all `quantum_portal_block` interior blocks are reliably removed.

### Description
- Reordered `onDestroyedByPlayer` in `CustomPortalBaseBlock` to call `CustomPortalBaseBlockDestroyedByPlayerProcedure.execute(...)` before `super.onDestroyedByPlayer(...)`.
- This preserves access to block entity NBT (fields like `portalWidth`, `portalHeight`, `portalMinExtent`, `portalMaxExtent`, and `rotation`) during teardown so the procedure can remove the full portal interior.
- Change is localized to `src/main/java/net/createteleporters/block/CustomPortalBaseBlock.java`.

### Testing
- Attempted to run `bash ./gradlew compileJava` but the Gradle wrapper download failed due to a network proxy returning `HTTP 403`, so compilation could not be completed in this environment.
- No other automated tests were executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce7de827648325ac3614dcf0479ee0)