### PR TITLE
Immersive Portals: robust creation/removal, scaling, and quantum-block cleanup

### DIFF
--- a/src/main/java/net/createteleporters/integration/ImmersivePortalsIntegration.java
+++ b/src/main/java/net/createteleporters/integration/ImmersivePortalsIntegration.java
@@ -1,10 +1,16 @@
 package net.createteleporters.integration;
 
 import net.createteleporters.CreateteleportersMod;
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.phys.Vec3;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.CommandSource;
@@ -45,6 +51,7 @@ public class ImmersivePortalsIntegration {
         
         int interiorWidth = Math.abs(maxExtent - minExtent) - 1;
         int interiorHeight = portalHeight - 1;
+        int sourceSquareSize = Math.max(1, Math.min(interiorWidth, interiorHeight));
         
         if (interiorWidth < 1 || interiorHeight < 1) {
             CreateteleportersMod.LOGGER.warn("Portal too small: {}x{}", interiorWidth, interiorHeight);
@@ -74,31 +81,47 @@ public class ImmersivePortalsIntegration {
         
         try {
             CreateteleportersMod.LOGGER.info("=== CREATING IP PORTAL ===");
-            CreateteleportersMod.LOGGER.info("Base: ({},{},{}) | Portal: ({},{},{}) | Size: {}x{}", 
-                x, y, z, portalX, portalY, portalZ, interiorWidth, interiorHeight);
+            CreateteleportersMod.LOGGER.info("Base: ({},{},{}) | Portal: ({},{},{}) | Frame size: {}x{} | Square size: {}", 
+                x, y, z, portalX, portalY, portalZ, interiorWidth, interiorHeight, sourceSquareSize);
             CreateteleportersMod.LOGGER.info("Target: {} ({},{},{})", targetDim, targetX, targetY, targetZ);
             CreateteleportersMod.LOGGER.info("Rotation: {}, Normal: {} (yaw={})", rotation, portalNormal, portalNormal.toYRot());
             
-            // Executor stands 1 block behind portal, facing the portal normal
-            // make_portal creates portal 1 block in front of executor, facing executor
-            double execX = portalX - portalNormal.getStepX();
+            // make_portal creates the portal one block in front of the executor and the
+            // created portal faces the executor. To make the portal face portalNormal,
+            // the executor must stand on the opposite side.
+            double execX = portalX + portalNormal.getStepX();
             double execY = portalY;
-            double execZ = portalZ - portalNormal.getStepZ();
+            double execZ = portalZ + portalNormal.getStepZ();
             
             CommandSourceStack cmdSource = getCommandSource(serverLevel, execX, execY, execZ, portalNormal, x, y, z);
             
-            // Create portal - destination is the OTHER portal's base position
-            String createCmd = String.format("portal make_portal %d %d %s %d %d %d",
-                interiorWidth, interiorHeight, targetDim,
-                (int) Math.floor(targetX), (int) Math.floor(targetY), (int) Math.floor(targetZ));
+            PortalTargetInfo targetInfo = resolveTargetPortalInfo(serverLevel, targetDim, targetX, targetY, targetZ,
+                rotation, minExtent, maxExtent, portalHeight);
+            double squareScale = targetInfo.squareSize / (double) sourceSquareSize;
+            double portalScale = Math.max(0.1, squareScale);
+
+            // Create portal with explicit Euler orientation to avoid block-hit based
+            // make_portal rotation ambiguity (which can create flat portals).
+            String createCmd = String.format(
+                "portal euler make_portal %.3f %.3f %.3f %.1f %.1f %d %d %.4f {}",
+                portalX, portalY, portalZ, 0.0f, portalNormal.toYRot(), sourceSquareSize, sourceSquareSize, portalScale
+            );
             
             serverLevel.getServer().getCommands().performPrefixedCommand(cmdSource.withSuppressedOutput(), createCmd);
             CreateteleportersMod.LOGGER.info("Executed: {}", createCmd);
-            
-            // Set destination explicitly
-            String destCmd = String.format("portal set_portal_destination %s %d %d %d",
-                targetDim, (int) Math.floor(targetX), (int) Math.floor(targetY), (int) Math.floor(targetZ));
-            executeAtPosition(serverLevel, portalX, portalY, portalZ, destCmd, true);
+
+            // Set destination to the target portal center before making this portal
+            // bi-way/bi-faced, so generated reverse portals are centered correctly.
+            String destCmd = String.format("portal set_portal_destination %s %.3f %.3f %.3f",
+                targetDim, targetInfo.center.x, targetInfo.center.y, targetInfo.center.z);
+            executeAsNearestPortal(serverLevel, portalX, portalY, portalZ, destCmd, true);
+            CreateteleportersMod.LOGGER.info("Executed: {}", destCmd);
+
+            // Make the portal bi-way and bi-faced (4 connected portal entities total)
+            // so both sides in both dimensions work automatically.
+            String completeCmd = "portal complete_bi_way_bi_faced_portal";
+            executeAsNearestPortal(serverLevel, portalX, portalY, portalZ, completeCmd, true);
+            CreateteleportersMod.LOGGER.info("Executed: {}", completeCmd);
             
             CreateteleportersMod.LOGGER.info("=== PORTAL CREATED ===");
             return true;
@@ -115,7 +138,7 @@ public class ImmersivePortalsIntegration {
         }
         
         try {
-            executeAtPosition(serverLevel, x + 0.5, y + 1.5, z + 0.5, "portal delete_portal", true);
+            executeAsNearestPortal(serverLevel, x + 0.5, y + 1.5, z + 0.5, "portal eradicate_portal_cluster", true);
             CreateteleportersMod.LOGGER.info("Removed IP portal");
             return true;
         } catch (Exception e) {
@@ -130,26 +153,19 @@ public class ImmersivePortalsIntegration {
     }
     
     private static Direction getPortalNormal(String rotation) {
-        // The direction you walk THROUGH the portal
+        // Block "rotation" stores the frame-facing direction.
+        // The portal normal for command placement needs the opposite direction.
         return switch (rotation) {
-            case "north" -> Direction.NORTH;  // Walk north through it
-            case "south" -> Direction.SOUTH;  // Walk south through it
-            case "east" -> Direction.EAST;
-            case "west" -> Direction.WEST;
+            case "north" -> Direction.SOUTH;
+            case "south" -> Direction.NORTH;
+            case "east" -> Direction.WEST;
+            case "west" -> Direction.EAST;
             default -> Direction.NORTH;
         };
     }
     
     private static CommandSourceStack getCommandSource(ServerLevel level, double px, double py, double pz, 
             Direction facing, double refX, double refY, double refZ) {
-        net.minecraft.world.entity.player.Player playerEntity = level.getNearestPlayer(refX, refY, refZ, 64, false);
-        
-        if (playerEntity instanceof net.minecraft.server.level.ServerPlayer player) {
-            return player.createCommandSourceStack()
-                .withPosition(new Vec3(px, py, pz))
-                .withRotation(new net.minecraft.world.phys.Vec2(0, facing.toYRot()));
-        }
-        
         return new CommandSourceStack(CommandSource.NULL, new Vec3(px, py, pz),
             new net.minecraft.world.phys.Vec2(0, facing.toYRot()),
             level, 4, "", Component.literal(""), level.getServer(), null);
@@ -157,18 +173,9 @@ public class ImmersivePortalsIntegration {
     
     private static void executeAtPosition(ServerLevel level, double x, double y, double z, 
             String command, boolean suppress) {
-        net.minecraft.world.entity.player.Player playerEntity = level.getNearestPlayer(x, y, z, 64, false);
-        
-        CommandSourceStack cmdSource;
-        if (playerEntity instanceof net.minecraft.server.level.ServerPlayer player) {
-            cmdSource = player.createCommandSourceStack()
-                .withPosition(new Vec3(x, y, z))
-                .withRotation(new net.minecraft.world.phys.Vec2(0, 0));
-        } else {
-            cmdSource = new CommandSourceStack(CommandSource.NULL, new Vec3(x, y, z),
-                new net.minecraft.world.phys.Vec2(0, 0), level, 4, "", Component.literal(""),
-                level.getServer(), null);
-        }
+        CommandSourceStack cmdSource = new CommandSourceStack(CommandSource.NULL, new Vec3(x, y, z),
+            new net.minecraft.world.phys.Vec2(0, 0), level, 4, "", Component.literal(""),
+            level.getServer(), null);
         
         if (suppress) {
             cmdSource = cmdSource.withSuppressedOutput();
@@ -176,4 +183,63 @@ public class ImmersivePortalsIntegration {
         
         level.getServer().getCommands().performPrefixedCommand(cmdSource, command);
     }
+
+    private static void executeAsNearestPortal(ServerLevel level, double x, double y, double z,
+            String portalCommand, boolean suppress) {
+        String command = String.format(
+            "execute positioned %.3f %.3f %.3f as @e[type=immersive_portals:portal,sort=nearest,limit=1,distance=..3] run %s",
+            x, y, z, portalCommand
+        );
+        executeAtPosition(level, x, y, z, command, suppress);
+    }
+
+    private static PortalTargetInfo resolveTargetPortalInfo(ServerLevel sourceLevel, String targetDimId,
+            double targetBaseX, double targetBaseY, double targetBaseZ,
+            String fallbackRotation, int fallbackMinExtent, int fallbackMaxExtent, int fallbackPortalHeight) {
+        String rotation = fallbackRotation;
+        int minExtent = fallbackMinExtent;
+        int maxExtent = fallbackMaxExtent;
+        int portalHeight = fallbackPortalHeight;
+
+        ResourceLocation dimLocation = ResourceLocation.tryParse(targetDimId);
+        if (dimLocation != null) {
+            ResourceKey<Level> dimKey = ResourceKey.create(Registries.DIMENSION, dimLocation);
+            ServerLevel targetLevel = sourceLevel.getServer().getLevel(dimKey);
+            if (targetLevel != null) {
+                BlockEntity targetBe = targetLevel.getBlockEntity(BlockPos.containing(targetBaseX, targetBaseY, targetBaseZ));
+                if (targetBe != null) {
+                    var nbt = targetBe.getPersistentData();
+                    if (nbt.contains("rotation")) {
+                        rotation = nbt.getString("rotation");
+                    }
+                    if (nbt.contains("portalMinExtent")) {
+                        minExtent = nbt.getInt("portalMinExtent");
+                    }
+                    if (nbt.contains("portalMaxExtent")) {
+                        maxExtent = nbt.getInt("portalMaxExtent");
+                    }
+                    if (nbt.contains("portalHeight")) {
+                        portalHeight = nbt.getInt("portalHeight");
+                    }
+                }
+            }
+        }
+
+        int baseX = (int) Math.floor(targetBaseX);
+        int baseY = (int) Math.floor(targetBaseY);
+        int baseZ = (int) Math.floor(targetBaseZ);
+        int interiorHeight = Math.max(1, portalHeight - 1);
+        int interiorWidth = Math.max(1, Math.abs(maxExtent - minExtent) - 1);
+        int squareSize = Math.max(1, Math.min(interiorWidth, interiorHeight));
+        int extentCenter = (minExtent + maxExtent) / 2;
+        int portalBottomY = baseY + 1;
+        int portalCenterY = portalBottomY + interiorHeight / 2;
+
+        if ("north".equals(rotation) || "south".equals(rotation)) {
+            return new PortalTargetInfo(new Vec3(baseX + extentCenter + 0.5, portalCenterY + 0.5, baseZ + 0.5), squareSize);
+        }
+        return new PortalTargetInfo(new Vec3(baseX + 0.5, portalCenterY + 0.5, baseZ + extentCenter + 0.5), squareSize);
+    }
+
+    private record PortalTargetInfo(Vec3 center, int squareSize) {}
 }

--- a/src/main/java/net/createteleporters/procedures/CustomPortalBaseBlockDestroyedByPlayerProcedure.java
+++ b/src/main/java/net/createteleporters/procedures/CustomPortalBaseBlockDestroyedByPlayerProcedure.java
@@ -5,9 +5,13 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.Level;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 
+import net.createteleporters.configuration.CTPConfigConfiguration;
+import net.createteleporters.integration.ImmersivePortalsIntegration;
 import net.createteleporters.init.CreateteleportersModBlocks;
 
 public class CustomPortalBaseBlockDestroyedByPlayerProcedure {
@@ -33,6 +37,32 @@ public class CustomPortalBaseBlockDestroyedByPlayerProcedure {
 				nbt.putBoolean("portalActive", false);
 				if (world instanceof Level _level)
 					_level.sendBlockUpdated(basePos, world.getBlockState(basePos), world.getBlockState(basePos), 3);
+			}
+		}
+
+		// If using Immersive Portals, remove this portal and the linked portal cluster.
+		if (CTPConfigConfiguration.IMMERSIVE_PORTALS_COMPAT.get()
+				&& ImmersivePortalsIntegration.isImmersivePortalsLoaded()
+				&& world instanceof ServerLevel sourceLevel) {
+			ImmersivePortalsIntegration.removeImmersivePortal(world, x, y, z);
+
+			if (blockEntity != null) {
+				CompoundTag nbt = blockEntity.getPersistentData();
+				if (nbt.getBoolean("isLinked")) {
+					String linkedDimId = nbt.getString("linkedDim");
+					ResourceLocation linkedDimLoc = ResourceLocation.tryParse(linkedDimId);
+					if (linkedDimLoc != null) {
+						ResourceKey<net.minecraft.world.level.Level> linkedDimKey = ResourceKey
+								.create(net.minecraft.core.registries.Registries.DIMENSION, linkedDimLoc);
+						ServerLevel linkedLevel = sourceLevel.getServer().getLevel(linkedDimKey);
+						if (linkedLevel != null) {
+							double linkedX = nbt.getDouble("linkedX");
+							double linkedY = nbt.getDouble("linkedY");
+							double linkedZ = nbt.getDouble("linkedZ");
+							ImmersivePortalsIntegration.removeImmersivePortal(linkedLevel, linkedX, linkedY, linkedZ);
+						}
+					}
+				}
 			}
 		}
 		

--- a/src/main/java/net/createteleporters/procedures/CustomPortalBaseOnTickUpdateProcedure.java
+++ b/src/main/java/net/createteleporters/procedures/CustomPortalBaseOnTickUpdateProcedure.java
@@ -59,6 +59,8 @@ public class CustomPortalBaseOnTickUpdateProcedure {
 				if (useImmersivePortals && ImmersivePortalsIntegration.isImmersivePortalsLoaded()) {
 					// Use Immersive Portals integration - NO quantum portal blocks
 					// IP handles the portal rendering and teleportation automatically
+					clearQuantumPortalBlocks(world, x, y, z, rotation, portalWidth, portalHeight, minExtent, maxExtent);
+
 					BlockEntity be = world.getBlockEntity(BlockPos.containing(x, y, z));
 					String targetDim = be != null ? be.getPersistentData().getString("linkedDim") : "minecraft:overworld";
 					double tx = be != null ? be.getPersistentData().getDouble("linkedX") : x;
@@ -292,6 +294,7 @@ public class CustomPortalBaseOnTickUpdateProcedure {
 						be.getPersistentData().putBoolean("immersivePortalCreated", false);
 					}
 				}
+				clearQuantumPortalBlocks(world, x, y, z, rotation, portalWidth, portalHeight, minExtent, maxExtent);
 			} else if (portalWidth > 0 && portalHeight > 0) {
 				// Use interior dimensions (not the frame)
 				int interiorMin = minExtent + 1;
@@ -327,6 +330,49 @@ public class CustomPortalBaseOnTickUpdateProcedure {
 			}
 		}
 		return "Portal Frame Incorrect";
+	}
+
+	private static void clearQuantumPortalBlocks(LevelAccessor world, double x, double y, double z, String rotation,
+			int portalWidth, int portalHeight, int minExtent, int maxExtent) {
+		if (!(world instanceof ServerLevel level)) {
+			return;
+		}
+
+		if (portalWidth > 0 && portalHeight > 0) {
+			int interiorMin = minExtent + 1;
+			int interiorMax = maxExtent - 1;
+			int fillHeight = portalHeight - 1;
+
+			if ("east".equals(rotation) || "west".equals(rotation)) {
+				level.getServer().getCommands().performPrefixedCommand(
+						new CommandSourceStack(CommandSource.NULL, new Vec3(x, y, z), Vec2.ZERO, level, 4, "",
+								Component.literal(""), level.getServer(), null).withSuppressedOutput(),
+						"fill ~ ~1 ~" + interiorMin + " ~ ~" + fillHeight + " ~" + interiorMax
+								+ " air replace createteleporters:quantum_portal_block");
+				return;
+			}
+
+			if ("north".equals(rotation) || "south".equals(rotation)) {
+				level.getServer().getCommands().performPrefixedCommand(
+						new CommandSourceStack(CommandSource.NULL, new Vec3(x, y, z), Vec2.ZERO, level, 4, "",
+								Component.literal(""), level.getServer(), null).withSuppressedOutput(),
+						"fill ~" + interiorMin + " ~1 ~ ~" + interiorMax + " ~" + fillHeight
+								+ " ~ air replace createteleporters:quantum_portal_block");
+				return;
+			}
+		}
+
+		if ("east".equals(rotation) || "west".equals(rotation)) {
+			level.getServer().getCommands().performPrefixedCommand(
+					new CommandSourceStack(CommandSource.NULL, new Vec3(x, y, z), Vec2.ZERO, level, 4, "",
+							Component.literal(""), level.getServer(), null).withSuppressedOutput(),
+					"fill ~ ~1 ~-1 ~ ~3 ~1 air replace createteleporters:quantum_portal_block");
+		} else if ("north".equals(rotation) || "south".equals(rotation)) {
+			level.getServer().getCommands().performPrefixedCommand(
+					new CommandSourceStack(CommandSource.NULL, new Vec3(x, y, z), Vec2.ZERO, level, 4, "",
+							Component.literal(""), level.getServer(), null).withSuppressedOutput(),
+					"fill ~-1 ~1 ~ ~1 ~3 ~ air replace createteleporters:quantum_portal_block");
+		}
 	}
 
 	private static boolean getBlockNBTLogic(LevelAccessor world, BlockPos pos, String tag) {


### PR DESCRIPTION
### Motivation
- Add full Immersive Portals compatibility so portals are created with correct orientation, scale, and bi-directional behavior while preventing leftover quantum portal blocks and handling linked portals across dimensions.

### Description
- Reworked `ImmersivePortalsIntegration` to compute source/target square sizes, use Euler `make_portal` with explicit orientation and scale, set destinations via the nearest portal entity, and run `portal complete_bi_way_bi_faced_portal` to finalize portals; added `resolveTargetPortalInfo`, `PortalTargetInfo`, and `executeAsNearestPortal` helpers.
- Adjusted portal normal logic and removed player-dependent command execution by constructing explicit `CommandSourceStack` positions and rotations.
- Switched portal removal to `portal eradicate_portal_cluster` and added lookup of linked portal metadata (via block entity NBT and dimension keys) to remove linked portals in other dimensions when a base is destroyed.
- Added `clearQuantumPortalBlocks` and updated `CustomPortalBaseOnTickUpdateProcedure` and `CustomPortalBaseBlockDestroyedByPlayerProcedure` to clear vanilla quantum blocks when Immersive Portals compatibility is enabled and to avoid leaving duplicate portal blocks.

### Testing
- Project build succeeded using `./gradlew build`.
- Existing automated tests were executed with `./gradlew test` and passed.
- No new automated tests were added for these integration changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ceae03ed208325b652a145e8065ba1)