### PR TITLE
Make immersive portals static and add ambient portal particles

### DIFF
--- a/src/main/java/net/createteleporters/integration/ImmersivePortalsIntegration.java
+++ b/src/main/java/net/createteleporters/integration/ImmersivePortalsIntegration.java
@@ -122,6 +122,12 @@ public class ImmersivePortalsIntegration {
             String completeCmd = "portal complete_bi_way_bi_faced_portal";
             executeAsNearestPortal(serverLevel, portalX, portalY, portalZ, completeCmd, true);
             CreateteleportersMod.LOGGER.info("Executed: {}", completeCmd);
+
+            // Keep all nearby IP portal entities static so the portal cluster is immovable.
+            String lockPortalMotionCmd =
+                "execute as @e[type=immersive_portals:portal,distance=..6] run data merge entity @s {NoGravity:1b,Motion:[0.0d,0.0d,0.0d]}";
+            executeAtPosition(serverLevel, portalX, portalY, portalZ, lockPortalMotionCmd, true);
+            CreateteleportersMod.LOGGER.info("Executed: {}", lockPortalMotionCmd);
             
             CreateteleportersMod.LOGGER.info("=== PORTAL CREATED ===");
             return true;

--- a/src/main/java/net/createteleporters/procedures/CustomPortalBaseOnTickUpdateProcedure.java
+++ b/src/main/java/net/createteleporters/procedures/CustomPortalBaseOnTickUpdateProcedure.java
@@ -60,6 +60,18 @@ public class CustomPortalBaseOnTickUpdateProcedure {
 					// Use Immersive Portals integration - NO quantum portal blocks
 					// IP handles the portal rendering and teleportation automatically
 					clearQuantumPortalBlocks(world, x, y, z, rotation, portalWidth, portalHeight, minExtent, maxExtent);
+					// Ambient particles while immersive portals are enabled.
+					if (world instanceof ServerLevel _level) {
+						double particleX = ("north".equals(rotation) || "south".equals(rotation))
+								? x + (minExtent + maxExtent) / 2.0 + 0.5
+								: x + 0.5;
+						double particleY = y + (fillHeight / 2.0) + 1.0;
+						double particleZ = ("north".equals(rotation) || "south".equals(rotation))
+								? z + 0.5
+								: z + (minExtent + maxExtent) / 2.0 + 0.5;
+						_level.sendParticles(ParticleTypes.PORTAL, particleX, particleY, particleZ, 3, 0.35,
+								Math.max(0.2, fillHeight * 0.15), 0.35, 0.01);
+					}
 
 					BlockEntity be = world.getBlockEntity(BlockPos.containing(x, y, z));
 					String targetDim = be != null ? be.getPersistentData().getString("linkedDim") : "minecraft:overworld";


### PR DESCRIPTION
### Motivation
- Prevent Immersive Portals portal entities from drifting or being moved after creation so portal clusters remain fixed in the world and unaffected by physics or other entity motion.
- Provide ambient visual feedback while Immersive Portals compatibility is active so players can more easily notice enabled portals.

### Description
- Lock newly created Immersive Portals entities by running a command that merges `{NoGravity:1b,Motion:[0.0d,0.0d,0.0d]}` into nearby `immersive_portals:portal` entities via `executeAtPosition` in `ImmersivePortalsIntegration.createImmersivePortal` (file `src/main/java/net/createteleporters/integration/ImmersivePortalsIntegration.java`).
- Spawn ambient `ParticleTypes.PORTAL` particles centered over the portal interior while Immersive Portals mode is active inside `CustomPortalBaseOnTickUpdateProcedure` so enabled portals emit subtle portal particles (file `src/main/java/net/createteleporters/procedures/CustomPortalBaseOnTickUpdateProcedure.java`).

### Testing
- Attempted to compile Java with `./gradlew compileJava`, which failed due to the wrapper being non-executable in this environment (permission denied).
- Attempted `bash ./gradlew compileJava`, which failed while downloading the Gradle distribution because the environment's network/proxy returned `HTTP/1.1 403 Forbidden`.
- No other automated tests were run in this environment due to build/download restrictions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cef8117b548325af0dbbf278af1e69)