### PR TITLE
Enforce square custom portals and add Ponder scenes for Custom Portal Base

### DIFF
--- a/src/main/java/net/createteleporters/integration/ponder/CreateTeleportersPonderPlugin.java
+++ b/src/main/java/net/createteleporters/integration/ponder/CreateTeleportersPonderPlugin.java
@@ -1,0 +1,22 @@
+package net.createteleporters.integration.ponder;
+
+import net.createmod.ponder.api.registration.PonderPlugin;
+import net.createmod.ponder.api.registration.PonderSceneRegistrationHelper;
+
+import net.minecraft.resources.ResourceLocation;
+
+import net.createteleporters.init.CreateteleportersModBlocks;
+
+public class CreateTeleportersPonderPlugin implements PonderPlugin {
+	@Override
+	public String getModId() {
+		return "createteleporters";
+	}
+
+	@Override
+	public void registerScenes(PonderSceneRegistrationHelper<ResourceLocation> helper) {
+		helper.forComponents(CreateteleportersModBlocks.CUSTOM_PORTAL_BASE).addStoryBoard("c_portal_1", CreateTeleportersPonderScenes::customPortalPage1)
+				.addStoryBoard("c_portal_2", CreateTeleportersPonderScenes::customPortalPage2)
+				.addStoryBoard("c_portal_3", CreateTeleportersPonderScenes::customPortalPage3);
+	}
+}

--- a/src/main/java/net/createteleporters/integration/ponder/CreateTeleportersPonderScenes.java
+++ b/src/main/java/net/createteleporters/integration/ponder/CreateTeleportersPonderScenes.java
@@ -1,0 +1,32 @@
+package net.createteleporters.integration.ponder;
+
+import com.simibubi.create.foundation.ponder.CreateSceneBuilder;
+
+import net.minecraft.core.Direction;
+
+import net.createmod.ponder.api.scene.SceneBuilder;
+import net.createmod.ponder.api.scene.SceneBuildingUtil;
+
+public class CreateTeleportersPonderScenes {
+	public static void customPortalPage1(SceneBuilder scene, SceneBuildingUtil util) {
+		renderWholeSchematic(scene, util, "c_portal_1", "Portal Controller Setup");
+	}
+
+	public static void customPortalPage2(SceneBuilder scene, SceneBuildingUtil util) {
+		renderWholeSchematic(scene, util, "c_portal_2", "Building a Square Portal Frame");
+	}
+
+	public static void customPortalPage3(SceneBuilder scene, SceneBuildingUtil util) {
+		renderWholeSchematic(scene, util, "c_portal_3", "Activating and Linking the Portal");
+	}
+
+	private static void renderWholeSchematic(SceneBuilder scene, SceneBuildingUtil util, String sceneId, String title) {
+		CreateSceneBuilder builder = new CreateSceneBuilder(scene);
+		builder.title(sceneId, title);
+		builder.configureBasePlate(0, 0, 5);
+		builder.world().showSection(util.select().layer(0), Direction.UP);
+		builder.idle(10);
+		builder.world().showSection(util.select().layersFrom(1), Direction.DOWN);
+		builder.idle(40);
+	}
+}

--- a/src/main/java/net/createteleporters/procedures/ScalablePortalCheckerProcedure.java
+++ b/src/main/java/net/createteleporters/procedures/ScalablePortalCheckerProcedure.java
@@ -15,15 +15,17 @@ import net.createteleporters.init.CreateteleportersModBlocks;
 
 /**
  * Checks for a valid scalable custom portal frame.
- * 
+ *
  * Portal structure:
  * - Bottom row: quantum_casing(s) - dummy - base - dummy - quantum_casing(s)
  * - Side rows: quantum casing on both ends, air/portal interior
  * - Top row: all quantum casing
- * 
- * Minimum size: 5 wide x 4 tall (3x2 interior)
+ *
+ * Minimum size: 5 wide x 5 tall (3x3 interior)
  * Maximum size: 23 wide x 23 tall (21x21 interior)
  * The base can be anywhere on the bottom row (must have dummy on each side)
+ *
+ * Note: Portal frames must be perfect squares.
  */
 public class ScalablePortalCheckerProcedure {
 	public static void execute(LevelAccessor world, double x, double y, double z) {
@@ -44,7 +46,7 @@ public class ScalablePortalCheckerProcedure {
 
 		// Find the valid portal dimensions
 		PortalDimensions dims = findValidPortalDimensions(world, BlockPos.containing(x, y, z), isHorizontal);
-		
+
 		if (dims != null) {
 			// Store the portal dimensions for later use
 			storePortalDimensions(world, BlockPos.containing(x, y, z), dims.width, dims.height, dims.minExtent, dims.maxExtent);
@@ -62,15 +64,15 @@ public class ScalablePortalCheckerProcedure {
 	private static PortalDimensions findValidPortalDimensions(LevelAccessor world, BlockPos basePos, boolean horizontal) {
 		// The base must have dummy blocks on both sides on the bottom row
 		Direction.Axis axis = horizontal ? Direction.Axis.Z : Direction.Axis.X;
-		
+
 		// First, verify dummy blocks are adjacent to the base
 		BlockPos leftDummyPos = horizontal ? basePos.offset(0, 0, -1) : basePos.offset(-1, 0, 0);
 		BlockPos rightDummyPos = horizontal ? basePos.offset(0, 0, 1) : basePos.offset(1, 0, 0);
-		
+
 		if (!isDummyBlock(world, leftDummyPos) || !isDummyBlock(world, rightDummyPos)) {
 			return null; // Must have dummy blocks on both sides
 		}
-		
+
 		// Scan left/bottom from the left dummy to find quantum casing extent
 		int minExtent = -1; // Start at left dummy position
 		for (int i = 2; i <= 23; i++) {
@@ -81,7 +83,7 @@ public class ScalablePortalCheckerProcedure {
 				break;
 			}
 		}
-		
+
 		// Scan right/top from the right dummy to find quantum casing extent
 		int maxExtent = 1; // Start at right dummy position
 		for (int i = 2; i <= 23; i++) {
@@ -92,7 +94,7 @@ public class ScalablePortalCheckerProcedure {
 				break;
 			}
 		}
-		
+
 		// Calculate total width (must be at least 5: 1q + 1d + 1c + 1d + 1q)
 		int totalWidth = maxExtent - minExtent + 1;
 		if (totalWidth < 5 || totalWidth > 23) {
@@ -108,8 +110,7 @@ public class ScalablePortalCheckerProcedure {
 			BlockPos rightPos = horizontal ? basePos.offset(0, h, maxExtent) : basePos.offset(maxExtent, h, 0);
 
 			// Both sides must be quantum casing
-			if (world.getBlockState(leftPos).getBlock() != CreateteleportersModBlocks.QUANTUM_CASING.get() ||
-				world.getBlockState(rightPos).getBlock() != CreateteleportersModBlocks.QUANTUM_CASING.get()) {
+			if (world.getBlockState(leftPos).getBlock() != CreateteleportersModBlocks.QUANTUM_CASING.get() || world.getBlockState(rightPos).getBlock() != CreateteleportersModBlocks.QUANTUM_CASING.get()) {
 				break;
 			}
 
@@ -149,28 +150,30 @@ public class ScalablePortalCheckerProcedure {
 			}
 		}
 
-		// Minimum height is 4 (bottom row + 3 more for 2-block interior + top)
-		if (maxHeight < 4) {
+		// Minimum height is 5 (bottom row + 4 more for 3-block interior + top)
+		if (maxHeight < 5) {
 			return null;
 		}
-		
+
+		// Restrict valid portal frame to perfect square dimensions
+		if (totalWidth != maxHeight) {
+			return null;
+		}
+
 		// Verify all interior blocks are air or portal blocks (not frame blocks)
 		for (int h = 1; h < maxHeight; h++) {
 			for (int w = minExtent + 1; w < maxExtent; w++) {
 				BlockPos interiorPos = horizontal ? basePos.offset(0, h, w) : basePos.offset(w, h, 0);
 				BlockState state = world.getBlockState(interiorPos);
 				// Allow air, custom portal blocks, quantum portal block (filled interior), or the base/dummy at bottom
-				if (!state.isAir() &&
-					state.getBlock() != CreateteleportersModBlocks.CUSTOM_PORTAL.get() &&
-					state.getBlock() != CreateteleportersModBlocks.CUSTOM_PORTAL_BASE.get() &&
-					state.getBlock() != CreateteleportersModBlocks.CUSTOM_PORTAL_ON.get() &&
-					state.getBlock() != CreateteleportersModBlocks.CUSTOM_PORTAL_BASE_DUMMY_BLOCK.get() &&
-					state.getBlock() != CreateteleportersModBlocks.QUANTUM_PORTAL_BLOCK.get()) {
+				if (!state.isAir() && state.getBlock() != CreateteleportersModBlocks.CUSTOM_PORTAL.get() && state.getBlock() != CreateteleportersModBlocks.CUSTOM_PORTAL_BASE.get()
+						&& state.getBlock() != CreateteleportersModBlocks.CUSTOM_PORTAL_ON.get() && state.getBlock() != CreateteleportersModBlocks.CUSTOM_PORTAL_BASE_DUMMY_BLOCK.get()
+						&& state.getBlock() != CreateteleportersModBlocks.QUANTUM_PORTAL_BLOCK.get()) {
 					return null;
 				}
 			}
 		}
-		
+
 		return new PortalDimensions(totalWidth, maxHeight, minExtent, maxExtent);
 	}
 

--- a/src/main/resources/META-INF/services/net.createmod.ponder.api.registration.PonderPlugin
+++ b/src/main/resources/META-INF/services/net.createmod.ponder.api.registration.PonderPlugin
@@ -1,0 +1,1 @@
+net.createteleporters.integration.ponder.CreateTeleportersPonderPlugin

--- a/src/main/resources/assets/createteleporters/lang/en_us.json
+++ b/src/main/resources/assets/createteleporters/lang/en_us.json
@@ -54,9 +54,12 @@
   "block.createteleporters.block_teleporter": "Block Teleporter",
   "gui.createteleporters.block_teleporter_gui.label_entity_teleporter": "Block Teleporter",
   "gui.createteleporters.block_teleporter_gui.label_tp_link": "Advanced TP Link",
-  "block.createteleporters.block_teleporter.description_0": "§6Redstone Signal To Activate",
-  "block.createteleporters.teleporter.description_0": "§6Stand On To Activate",
-  "block.createteleporters.entity_teleporter_slab.description_0": "§6Stand On To Activate",
-  "block.createteleporters.entity_teleporter_quarter.description_0": "§6Stand On To Activate",
-  "block.createteleporters.item_tp.description_0": "§6Redstone Signal To Activate"
+  "block.createteleporters.block_teleporter.description_0": "\u00a76Redstone Signal To Activate",
+  "block.createteleporters.teleporter.description_0": "\u00a76Stand On To Activate",
+  "block.createteleporters.entity_teleporter_slab.description_0": "\u00a76Stand On To Activate",
+  "block.createteleporters.entity_teleporter_quarter.description_0": "\u00a76Stand On To Activate",
+  "block.createteleporters.item_tp.description_0": "\u00a76Redstone Signal To Activate",
+  "createteleporters.ponder.c_portal_1.header": "Portal Controller Setup",
+  "createteleporters.ponder.c_portal_2.header": "Building a Square Portal Frame",
+  "createteleporters.ponder.c_portal_3.header": "Activating and Linking the Portal"
 }


### PR DESCRIPTION
### Motivation
- Ensure custom portal frames are validated as perfect squares to avoid non-square/unsupported portal shapes. 
- Provide Create-style Ponder documentation pages for the custom portal base that show the existing schematics `c_portal_1`, `c_portal_2`, and `c_portal_3`.

### Description
- Updated `ScalablePortalCheckerProcedure` to require `totalWidth == maxHeight`, raised the minimum validated height to `5` (3x3 interior) and added a note that frames must be perfect squares. 
- Added a Ponder plugin `CreateTeleportersPonderPlugin` that registers three storyboards (`c_portal_1`, `c_portal_2`, `c_portal_3`) for `CreateteleportersModBlocks.CUSTOM_PORTAL_BASE`. 
- Added `CreateTeleportersPonderScenes` which renders each schematic page using `CreateSceneBuilder` and the provided schematic ids. 
- Added service loader registration at `META-INF/services/net.createmod.ponder.api.registration.PonderPlugin` and localization keys in `en_us.json` for the three Ponder page headers.

### Testing
- Attempted to compile with `./gradlew -q compileJava`, but the Gradle wrapper failed to download dependencies due to a proxy error (`HTTP 403`), so compilation could not be verified in this environment. 
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfa76638ac83259be615a560a5eedc)