### PR TITLE
Fix ponder registration for custom portal base

### DIFF
--- a/src/main/java/net/createteleporters/integration/ponder/CreateTeleportersPonderPlugin.java
+++ b/src/main/java/net/createteleporters/integration/ponder/CreateTeleportersPonderPlugin.java
@@ -4,6 +4,8 @@ import net.createmod.ponder.api.registration.PonderPlugin;
 import net.createmod.ponder.api.registration.PonderSceneRegistrationHelper;
 
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.world.level.block.Block;
 
 import net.createteleporters.init.CreateteleportersModBlocks;
 
@@ -15,7 +17,9 @@ public class CreateTeleportersPonderPlugin implements PonderPlugin {
 
 	@Override
 	public void registerScenes(PonderSceneRegistrationHelper<ResourceLocation> helper) {
-		helper.forComponents(CreateteleportersModBlocks.CUSTOM_PORTAL_BASE.getId()).addStoryBoard("c_portal_1", CreateTeleportersPonderScenes::customPortalPage1)
+		PonderSceneRegistrationHelper<Block> blockHelper = helper.withKeyFunction(BuiltInRegistries.BLOCK::getKey);
+
+		blockHelper.forComponents(CreateteleportersModBlocks.CUSTOM_PORTAL_BASE.get()).addStoryBoard("c_portal_1", CreateTeleportersPonderScenes::customPortalPage1)
 				.addStoryBoard("c_portal_2", CreateTeleportersPonderScenes::customPortalPage2)
 				.addStoryBoard("c_portal_3", CreateTeleportersPonderScenes::customPortalPage3);
 	}


### PR DESCRIPTION
### Motivation
- The `custom_portal_base` block did not reliably show the “W to ponder” hint; registration needed to match Create/Ponder expectations so the block resolves correctly in the Ponder index.

### Description
- Changed `src/main/java/net/createteleporters/integration/ponder/CreateTeleportersPonderPlugin.java` to use `helper.withKeyFunction(BuiltInRegistries.BLOCK::getKey)` and register the block via `CreateteleportersModBlocks.CUSTOM_PORTAL_BASE.get()` instead of its raw id, and added the required imports (`BuiltInRegistries`, `Block`); the three storyboards (`c_portal_1`, `c_portal_2`, `c_portal_3`) remain unchanged.

### Testing
- Ran `bash ./gradlew compileJava -q` to validate the change, but the build could not complete in this environment because the Gradle wrapper download was blocked by a proxy (`HTTP 403 Forbidden`), so no successful automated compilation was performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfabda50f883258da9272876a992e8)